### PR TITLE
fix: fixed crash on Android 12+ by adding FLAG_IMMUTABLE to PendingIntent in MediaPlayerService

### DIFF
--- a/app/src/main/java/ict/ihu/gr/loopify/MediaPlayerService.java
+++ b/app/src/main/java/ict/ihu/gr/loopify/MediaPlayerService.java
@@ -64,12 +64,12 @@ public class MediaPlayerService extends Service {
         // Play action
         Intent playIntent = new Intent(this, MediaPlayerService.class);
         playIntent.setAction("PLAY");
-        PendingIntent playPendingIntent = PendingIntent.getService(this, 0, playIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent playPendingIntent = PendingIntent.getService(this, 0, playIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
         // Pause action
         Intent pauseIntent = new Intent(this, MediaPlayerService.class);
         pauseIntent.setAction("PAUSE");
-        PendingIntent pausePendingIntent = PendingIntent.getService(this, 1, pauseIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent pausePendingIntent = PendingIntent.getService(this, 1, pauseIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
         // Choose which action (play or pause) to show based on the isPlaying flag
         NotificationCompat.Action action;


### PR DESCRIPTION
This pull request fixes a crash occurring on Android 12 (API level 31) and above due to missing FLAG_IMMUTABLE in PendingIntent instances within the MediaPlayerService